### PR TITLE
Small grammar fix

### DIFF
--- a/content/docs/installation.html.haml
+++ b/content/docs/installation.html.haml
@@ -194,7 +194,7 @@ category: docs
 
 .title Not Using Rails 3?
 .text
-  You can initialize Mongoid in it's configuration block, either by calling the above
+  You can initialize Mongoid in its configuration block, either by calling the above
   mentioned methods directly or using <tt>from_hash</tt> to load in a mongoid.yml:
 
   %pre

--- a/content/docs/validation.html.haml
+++ b/content/docs/validation.html.haml
@@ -24,7 +24,7 @@ category: docs
 
 %p
   In addition to those validations, information is provided with each macro
-  about it's specific options.
+  about its specific options.
 
 %p
   %i Validate the acceptance of a boolean field:


### PR DESCRIPTION
"It's" means "it is".
