### PR TITLE
Tests don't run after following instructions for removing ActiveRecord

### DIFF
--- a/content/docs/installation.html.haml
+++ b/content/docs/installation.html.haml
@@ -159,6 +159,7 @@ category: docs
         require "action_controller/railtie"
         require "action_mailer/railtie"
         require "active_resource/railtie"
+        require "rails/test_unit/railtie"
   %ul
     %li Start up your app and welcome yourself to a life without ActiveRecord!
 


### PR DESCRIPTION
The instructions are missing:
    require "rails/test_unit/railtie"
