### PR TITLE
Tweaks the installation docs so they recommend the correct versions.

### DIFF
--- a/content/docs/installation.html.haml
+++ b/content/docs/installation.html.haml
@@ -24,8 +24,8 @@ category: docs
   %pre
     %code.language-ruby
       :preserve
-        gem "mongoid", "2.0.0.rc.5"
-        gem "bson_ext", "1.1.5"
+        gem "mongoid", "2.0.0.rc.6"
+        gem "bson_ext", "~> 1.2"
 
   Setup of the database connection itself is handled by using automatic configuration with
   a <tt>config/mongoid.yml</tt>. You can generate a mongoid.yml via the following command:


### PR DESCRIPTION
So this:

```
gem "mongoid", "2.0.0.rc.5"
gem "bson_ext", "1.1.5"
```

became this:

```
gem "mongoid", "2.0.0.rc.6"
gem "bson_ext", "~> 1.2"
```
