### PR TITLE
Removed double titles

### DIFF
--- a/content/docs/indexing.html.haml
+++ b/content/docs/indexing.html.haml
@@ -3,7 +3,6 @@ title: Indexing
 author: Durran Jordan
 category: docs
 ---
-.title Indexing
 .text
   You can define indexes on documents using the index macro. For unique indexes
   provide a unique options, otherwise no option is necessary.

--- a/content/docs/rake.html.haml
+++ b/content/docs/rake.html.haml
@@ -3,7 +3,6 @@ title: Rake Tasks
 author: Durran Jordan
 category: docs
 ---
-.title Rake Tasks
 .text
   Mongoid provides the following rake tasks when used in a Rails 3 environment:
 


### PR DESCRIPTION
The redundant titles in indexing and rake are, well, redundant!
