### PR TITLE
Fixed typo in embeded/1-n

### DIFF
--- a/views/docs/relations/embedded/1-n.html.haml
+++ b/views/docs/relations/embedded/1-n.html.haml
@@ -14,7 +14,7 @@
 
 %p
   The parent document of the relation should use the <tt>embeds_many</tt>
-  macro to indicate is has <i>n</i> number of embedded children, where
+  macro to indicate it has <i>n</i> number of embedded children, where
   the document that is embedded uses <tt>embedded_in</tt>.
 
 :coderay


### PR DESCRIPTION
Fixed the typo from is to it in views/docs/relations/embedded/1-n.html.haml
