### PR TITLE
Correct link to rdoc + messed markup

### DIFF
--- a/views/links.html.haml
+++ b/views/links.html.haml
@@ -8,26 +8,14 @@
 
   %ul
     %li
-      <a href="http://github.com/mongoid">
-      Mongoid Organization on Github
-      </a>
+      %a{ :href => 'http://github.com/mongoid' } Mongoid Organization on Github
     %li
-      <a href="http://groups.google.com/group/mongoid/">
-      Mongoid Google Group
-      </a>
+      %a{ :href => 'http://groups.google.com/group/mongoid/' } Mongoid Google Group
     %li
-      <a href="http://rdoc.info/github/mongoid/mongoid/master/frames">
-      Mongoid API Documentation
-      </a>
+      %a{ :href => 'http://rdoc.info/github/mongoid/mongoid/master/frames' } Mongoid API Documentation
     %li
-      <a href="http://twitter.com/modetojoy">
-      Mongoid (Durran) on Twitter
-      </a>
+      %a{ :href => 'http://twitter.com/modetojoy' } Mongoid (Durran) on Twitter
     %li
-      <a href="http://mongodb.org">
-      MongoDB
-      </a>
+      %a{ :href => 'http://mongodb.org' } MongoDB
     %li
-      <a href="http://api.mongodb.org/ruby">
-      MongoDB Ruby Driver Documentation
-      </a>
+      %a{ :href => 'http://api.mongodb.org/ruby' } MongoDB Ruby Driver Documentation


### PR DESCRIPTION
I've corrected the link to rdoc, which was broken. Also, instead of messing HAML and HTML syntaxes together put all links (in the "Links" section only) to HAML.
