### PR TITLE
updating bson_ext version in install docs

### DIFF
--- a/views/docs/installation.html.haml
+++ b/views/docs/installation.html.haml
@@ -46,7 +46,7 @@
 :coderay
   #!ruby
   gem "mongoid", "~> 2.0"
-  gem "bson_ext", "~> 1.2"
+  gem "bson_ext", "~> 1.3"
 
 %p
   Alternatively you can get the Mongoid gem direcly from rubygems.org:


### PR DESCRIPTION
2.0.1 is now using bson_ext ~> 1.3
