### PR TITLE
Adding a note about document class names not to be ended with 's' 

### DIFF
--- a/views/docs/documents.html.haml
+++ b/views/docs/documents.html.haml
@@ -30,8 +30,17 @@
   as the plural form of <tt>Statu</tt>, which will cause a few known problems.
 
 %p
-  This is a limitation of the <tt>ActiveSupport::Inflection#classify</tt> which
+  This is a limitation of the <tt>ActiveSupport::Inflector#classify</tt> which
   Mongoid uses to convert from filenames and collection names to class names.
+  You can overcome this by specifying a custom inflection rule for your model class.
+  For example, the following code will take care of the model named <tt>Status</tt>
+
+:coderay
+  #!ruby
+  ActiveSupport::Inflector.inflections do |inflect|
+    inflect.singular("status", "status")
+  end
+
 %br
 
 %p


### PR DESCRIPTION
Document class names ending with 's' will be considered as pluralized form and will cause some known problems for sure and probably other unknown problems too.

Also added the word "for" in the subsequent line as it made sense to have one - grammatically.

Corresponding discussion is here : http://groups.google.com/group/mongoid/browse_thread/thread/fb4f5fbcb8047e19
