### PR TITLE
Updated default_scope documentation

### DIFF
--- a/views/docs/querying/scopes.html.haml
+++ b/views/docs/querying/scopes.html.haml
@@ -116,7 +116,7 @@
     field :occupation, type: String
     field :age, type: Integer
 
-    default_scope :rock_n_rolla, where(occupation: "Rockstar")
+    default_scope where(occupation: "Rockstar")
     scope :washed_up, where(:age.gt => 30)
   end
 


### PR DESCRIPTION
The current sites documentation has default_scope accepting two arguments. The name of the scope and the scope itself.

However the latest code just accepts a scope, not a name.

I have updated the documentation to reflect this.
