### PR TITLE
Include Sprockets Railtie for Rails 3.1+

### DIFF
--- a/views/docs/installation/configuration.html.haml
+++ b/views/docs/installation/configuration.html.haml
@@ -44,6 +44,7 @@
   require "action_mailer/railtie"
   require "active_resource/railtie"
   require "rails/test_unit/railtie"
+  # require "sprockets/railtie" # Uncomment this line for Rails 3.1+
 
 %h3 sinatra, padrino, and others
 


### PR DESCRIPTION
Hi All,

If you take a look at https://github.com/rails/rails/blob/3-1-stable/railties/lib/rails/all.rb, it is also requiring `sprockets/railtie` however this is not listed in the documentation.

I've left it as a commented line, so that users are aware of this Railtie and can require it if they are using Rails 3.1+.

Please let me know if I have missed anything or should make any changes.

Thanks.
