### PR TITLE
Add usage examples for association extension

### DIFF
--- a/views/docs/relations.html.haml
+++ b/views/docs/relations.html.haml
@@ -53,8 +53,14 @@
       def find_by_country(country)
         where(country: country).first
       end
+      def chinese
+        @target.select { |address| address.country == "China"}
+      end
     end
   end
+
+  person.addresses.find_by_country('Mongolia') #=> returns address
+  person.addresses.chinese #=> returns [ address ]
 
 %h3 custom relation names
 


### PR DESCRIPTION
How to use association extensions could do with some clear examples. It 
would be nice to know, too, what the limitations of the extensions are. 
For instance, can I store additional data against an association, or 
must the extensions be query methods?
- Demonstrate existing 'find_by_country' example
- Demonstrate @target usage in association extension

Examples of usage were added in the older site documentation, but have 
since been dropped.
See: e65b18e7e3ec5a35d73a3324c7849dd41262f55a
