### PR TITLE
Changed #container width so when browser viewport is narrow, content does.  Close #85

### DIFF
--- a/views/stylesheets/site.css.sass
+++ b/views/stylesheets/site.css.sass
@@ -40,7 +40,7 @@ div.code
 
 div#container
   height: 100%
-  width: 100%
+  width: 780px
   z-index: 100
 
 div#centered


### PR DESCRIPTION
Changed #container width so when browser viewport is narrow, content doesn't squish out bottom.  Nicer when side by side developing/viewing documentation :P
