### PR TITLE
Parent-child hash fix

### DIFF
--- a/source/docs/relations/referenced/1-1.html.haml
+++ b/source/docs/relations/referenced/1-1.html.haml
@@ -50,8 +50,8 @@
 
   # The child post document.
   {
-    "_id" : ObjectId("4d3ed089fb60ab534684b7e9"),
-    "person_id" : ObjectId("4d3ed089fb60ab534684b7f1")
+    "_id" : ObjectId("4d3ed089fb60ab534684b7f1"),
+    "person_id" : ObjectId("4d3ed089fb60ab534684b7e9")
   }
 
 %h3 accessors


### PR DESCRIPTION
Switched the hashes so that the child's id is different from the parent, and the parent id is referenced in the child.
