### PR TITLE
Dropping Indexes not clearly defined

### DIFF
--- a/source/docs/indexing.html.haml
+++ b/source/docs/indexing.html.haml
@@ -95,3 +95,27 @@
   #!ruby
   defaults: &defaults
     autocreate_indexes: true
+
+
+%h3 dropping indexes
+
+%p
+  When you want to remove an index, it must be done using the MongoDB index name.
+  Therefore if you create a range index on the <i>birthday</i> date coluumn in the Person
+  model in the Rails console, you would do it like this.
+
+:coderay
+  #!ruby
+  :001 > Person.collection.ensure_index([['birthday',Mongo::DESCENDING]])
+
+%p
+  In order to delete that same index, you need to use the index name, not the index definition.
+  The index name is <i>birthday</i>, but the index definition according to MongoDB will include
+  an <i>_1</i> for an <i>Mongo::ASCENDING</i> range index and a <i>_-1</i> for a
+  <i>Mongo::DESCENDING</i> range index.  To remove the above index in the Rails console, you would
+  enter the following.
+
+:coderay
+  #!ruby
+  :002 > Person.collection.drop_index('birthday_-1')
+


### PR DESCRIPTION
For the most part, it looks easy to drop an index using Mongoid.  But it's not well explained that when you want to drop an index, you need to use the MongoDB name and not the field name (ie `foo` vs. `foo_1`).  It becomes even less obvious when you have `foo_-1` as the result of creating a range index.

I actually think the proper solution to this would be to have the driver be able to coerce `[['foo',Mongo::DESCENDING]]` into `foo_-1`, but in the absence of me having the time to do that, I decided instead to update the documentation with an explanation of how to drop an index in the Rails console.  I think it can also be fairly easily understood that the same methodology applies to something in a rake task.
