### PR TITLE
Fix for incorrect Haml indention on Indexing page

### DIFF
--- a/source/docs/indexing.html.haml
+++ b/source/docs/indexing.html.haml
@@ -44,8 +44,8 @@
     )
   end
 
-  %p
-    Indexes can be sparse:
+%p
+  Indexes can be sparse:
 
   :coderay
     #!ruby


### PR DESCRIPTION
The paragraph tag for "Indexes can be sparse:" on the Indexing page is indented too far inward and causes it to be part of the code block above it, and also causes the code below it to display incorrectly.
