### PR TITLE
referenced n-n accessor documentation.

### DIFF
--- a/source/docs/relations/referenced/n-n.html.haml
+++ b/source/docs/relations/referenced/n-n.html.haml
@@ -82,17 +82,17 @@
 :coderay
   #!ruby
 
-  # Return the tags.
+  # Return the tags that belong to a person.
   person.tags
 
   # Set the tags from the person.
   person.tags = [ Tag.new ]
 
-  # Return the person from the tag.
-  tag.person
+  # Return the people that belong to a tag.
+  tag.people
 
-  # Set the person from the tag.
-  tag.person = Person.new
+  # Set the people from the tag.
+  tag.people = [ Person.new ]
 
 %h3 building and creating
 


### PR DESCRIPTION
Think the documentation for the referenced n-n accessor was off.  This is the way it actually works to my understanding.  I assume someone just copy and pasted this text from the referenced 1-n accessor documentation and forgot to modify it accordingly.
