### PR TITLE
Replace regex validation example with secure variation.

### DIFF
--- a/source/docs/validation.html.haml
+++ b/source/docs/validation.html.haml
@@ -111,7 +111,7 @@
 
 :coderay
   #!ruby
-  validates_format_of :title, with: /^[A-Za-z]*$/
+  validates_format_of :title, with: /\A\w+\Z/
 
 %h4 <tt>validates_inclusion_of</tt>
 


### PR DESCRIPTION
The previous example given, `/[A-Za-z]/`, isn't very useful or secure
given that it passes any string containing an alphabetic character,
enabling potential XSS and db injection exploits.

The replacement, `/^[A-Za-z]*$/`, ensures that all the characters in the
string are alphabetical.

I understand that the purpose of the documentation is to explain Mongoid
not regexes, but I suggest the change be made for the sake of not
having a insecure example online.
