### PR TITLE
A helpful note on how to access deleted documents for the Paranoia module.

### DIFF
--- a/source/docs/extras.html.haml
+++ b/source/docs/extras.html.haml
@@ -78,6 +78,13 @@
   person.destroy! # Permanently delete the document with callbacks.
   person.restore # Brings the "deleted" document back to life.
 
+%p
+  The documents that have been "flagged" as deleted (soft deleted) can be accessed at any time by calling the <tt>deleted</tt> class method on the class.
+
+:coderay
+  #!ruby
+  Person.deleted # Returns documents that have been "flagged" as deleted.
+
 %h3 Versioning
 
 %p


### PR DESCRIPTION
Adding an explanation for how to access soft deleted documents for the Paranoia module.  It took me a while to figure this out, and I think it would be useful for most folks looking to implement this.
