### PR TITLE
Adding clarification about the 'delete_all' method on referenced relationships

### DIFF
--- a/source/docs/relations/referenced/1-n.html.haml
+++ b/source/docs/relations/referenced/1-n.html.haml
@@ -119,8 +119,9 @@
 :coderay
   #!ruby
 
-  # Delete all referenced documents
+  # Delete all referenced documents (regardless of <tt>:dependent</tt> option)
   person.posts.delete_all
+  # Delete, Nullify, or Destroy all referenced documents (depending on <tt>:dependent</tt> option)
   person.posts.clear
   person.posts = []
 
@@ -197,7 +198,8 @@
 %p
   You can tell Mongoid what to do with child relations of a has many
   when unsetting the relation via the dependent option. This also applies
-  to calling <tt>#delete</tt> on the relation. The valid options are:
+  to calling <tt>#delete</tt> on the relation (unless calling <tt>#delete_all</tt>).
+  The valid options are:
 
 %ul
   %li <tt>:delete</tt>: Delete the child documents.

--- a/source/docs/relations/referenced/n-n.html.haml
+++ b/source/docs/relations/referenced/n-n.html.haml
@@ -144,8 +144,9 @@
 :coderay
   #!ruby
 
-  # Delete all referenced documents
+  # Delete all referenced documents (regardless of <tt>:dependent</tt> option)
   person.tags.delete_all
+  # Delete, Nullify, or Destroy all referenced documents (depending on <tt>:dependent</tt> option)
   person.tags.clear
   person.tags = []
 
@@ -181,7 +182,8 @@
 %p
   You can tell Mongoid what to do with inverse relations of a many to many
   when unsetting the relation via the dependent option. This also applies
-  to calling <tt>#delete</tt> on the relation. The valid options are:
+  to calling <tt>#delete</tt> on the relation (unless calling <tt>#delete_all</tt>)..
+  The valid options are:
 
 %ul
   %li <tt>:delete</tt>: Delete the inverse documents.


### PR DESCRIPTION
This commit is an attempt to address #124.
