### PR TITLE
Fix default min/max on mongoid geospatial indexing docs

### DIFF
--- a/source/en/mongoid/docs/indexing.haml
+++ b/source/en/mongoid/docs/indexing.haml
@@ -74,7 +74,7 @@
     include Mongoid::Document
     field :location, type: Array
 
-    index({ location: "2d" }, { min: 200, max: 200 })
+    index({ location: "2d" }, { min: -200, max: 200 })
   end
 
 %p


### PR DESCRIPTION
Was 200, 200; now -200, 200
