### PR TITLE
Mention default state, and also how to have no logging.

### DIFF
--- a/source/en/mongoid/docs/installation.haml
+++ b/source/en/mongoid/docs/installation.haml
@@ -288,7 +288,7 @@
 
   %p
     Changing logging options is done simply by telling Mongoid or Moped's
-    logger to have a different level.
+    logger to have a different level. Logging is turned off by default.
 
   :coderay
     #!ruby


### PR DESCRIPTION
Default logging state is not mentioned. In my experiments, it seems that default state (when no calls to `Mongoid.logger.level` or `Moped.logger.level` are made) is to not have any logging. The docs for 2.x explicitly state how to turn logging off, it seems that the change in default behavior is worth mentioning, as is how to turn logging off. Please correct me if the behavior is different.
