### PR TITLE
replace stray li with closing bold marker

### DIFF
--- a/source/en/mongoid/docs/upgrading.haml
+++ b/source/en/mongoid/docs/upgrading.haml
@@ -153,7 +153,7 @@
     For custom ids, users must now override the _id field.
 
     %p
-      When the default value is a proc, the default is applied *after%li all
+      When the default value is a proc, the default is applied *after* all
       other attributes are set.
 
     :coderay


### PR DESCRIPTION
Stray HAML `li` was located where a star should have been to create bold text.
