### PR TITLE
adding order_by example

### DIFF
--- a/.rvmrc
+++ b/.rvmrc
@@ -1,1 +1,1 @@
-rvm use 1.9.3@mongoid-site
+rvm use 1.9.3@mongoid-site --create

--- a/source/en/mongoid/docs/querying.haml
+++ b/source/en/mongoid/docs/querying.haml
@@ -274,6 +274,20 @@
               #!ruby
               collections[:bands].find.count
               collections[:bands].find(name: "Photek").count
+        %tr
+          %td.doc
+            <code>Criteria#order_by</code>
+            %p.doc
+              %i
+                order the results by a given attribute
+          %td
+            :coderay
+              #!ruby
+              Band.order_by(:name => :asc, :id => :desc)
+              Band.asc(:name, :id)
+              Band.desc(:name, :id)
+          %td
+
 
   %h3 Eager Loading
 


### PR DESCRIPTION
I had to go back through some of my old 2.4 mongoid code to find the order_by syntax so i thought I would add a brief section to the docs site.

I'm not sure about the moped syntax so I left that blank.  Should I fill that in before I submit or just get the basic syntax that most people will need right away?
