### PR TITLE
A warning about hash field key values

### DIFF
--- a/source/en/mongoid/docs/documents.haml
+++ b/source/en/mongoid/docs/documents.haml
@@ -199,6 +199,36 @@
       first_name: "Jean-Baptiste",
       middle_name: "Emmanuel"
     )
+  
+  %h3 Hash Field Keys
+  
+  %p
+    When using a field of type <code>Hash</code>, be wary of adhering to the
+    = link_to 'legal key names for mongoDB', 'http://www.mongodb.org/display/DOCS/Legal+Key+Names'
+    , or else the values will not store properly.
+  
+  :coderay
+    #!ruby
+    
+    class Person
+      include Mongoid::Document
+      field :first_name
+      field :url, type: Hash
+      
+      # will update the fields properly and save the values
+      def set_vals
+        self.first_name = 'Daniel'
+        self.url = {'home_page' => 'http://www.homepage.com'}
+        save
+      end
+      
+      # all data will fail to save due to the illegal hashkey
+      def set_vals_fail
+        self.first_name = 'Daniel'
+        self.url = {'home.page' => 'http://www.homepage.com'}
+        save
+      end
+    end
 
   %h3 Defaults
 


### PR DESCRIPTION
This pull request adds a warning on the Documents page regarding ensuring that hash keys adhere to [Mongoid's legal key names](http://www.mongodb.org/display/DOCS/Legal+Key+Names), otherwise you risk data loss on all data set on an instance of a `Mongoid::Document` prior to calling `save` on said document (or `reload`).

This is in response to the discussion on [issue 2107 on the Mongoid github repo](https://github.com/mongoid/mongoid/issues/2107).

This seemed to be the most appropriate location for such a warning, but anyone can feel free to tweak this, or change the location of it as they see fit.  (Or even reject it in favor of a link to this warning elsewhere).  Cheers!
