### PR TITLE
Typo fix in persistence documentation

### DIFF
--- a/source/en/mongoid/docs/persistence.haml
+++ b/source/en/mongoid/docs/persistence.haml
@@ -104,7 +104,7 @@
             %i
               Saves the changed attributes to the database
               atomically, or insert the document if flagged as a new_record via
-              <code>Model#rew_record?</code>. Can bypass validations if wanted.
+              <code>Model#new_record?</code>. Can bypass validations if wanted.
         %td
           :coderay
             #!ruby


### PR DESCRIPTION
Just a little typo I found while reading the persistence documentation.
