### PR TITLE
Update source/en/mongoid/docs/indexing.haml

### DIFF
--- a/source/en/mongoid/docs/indexing.haml
+++ b/source/en/mongoid/docs/indexing.haml
@@ -74,7 +74,7 @@
     include Mongoid::Document
     field :location, type: Array
 
-    index({ location: "2d" }, { min: -200, max: 200 })
+    index({ location: "2d" })
   end
 
 %p


### PR DESCRIPTION
min and max are no longer valid options

docs should not reference options you can't use
