### PR TITLE
Typo fixes

### DIFF
--- a/source/en/mongoid/docs/documents.haml
+++ b/source/en/mongoid/docs/documents.haml
@@ -642,7 +642,7 @@
   %h3 Resetting changes
 
   %p
-    You can reset changes of a field to it's previous value by calling the
+    You can reset changes of a field to its previous value by calling the
     reset method.
 
   :coderay

--- a/source/en/mongoid/docs/identity_map.haml
+++ b/source/en/mongoid/docs/identity_map.haml
@@ -38,9 +38,9 @@
     Mongoid.identity_map_enabled = true
 
   %p
-    When a document is now loaded from the database, is is automatically
-    added to the identity map by it's class and id. Subsequent request for
-    that document by it's id will not hit the database, but rather pull
+    When a document is now loaded from the database, it is automatically
+    added to the identity map by its class and id. Subsequent request for
+    that document by its id will not hit the database, but rather pull
     the document back from the identity map itself.
 
   %p

--- a/source/en/mongoid/docs/installation.haml
+++ b/source/en/mongoid/docs/installation.haml
@@ -372,7 +372,7 @@
 
   %p
     If you are using Mongoid in a sharded MongoDB environment and want to tell
-    Mongoid to include the shard keys in it's updates, specify this at the
+    Mongoid to include the shard keys in its updates, specify this at the
     model class level.
 
   :coderay

--- a/source/en/mongoid/docs/persistence.haml
+++ b/source/en/mongoid/docs/persistence.haml
@@ -569,7 +569,7 @@
 
   %p
     Persisting using <code>with</code> is a <i>one time</i> switch in the persistence
-    context - it changes back to it's defaults immediately after. Mongoid
+    context - it changes back to its defaults immediately after. Mongoid
     will not remember anything specific on the document level regarding how it was
     saved when using this method. A potential gotcha with this is persisting a document
     via <code>with</code> and then immediately updating it after.

--- a/source/en/mongoid/docs/querying.haml
+++ b/source/en/mongoid/docs/querying.haml
@@ -55,8 +55,8 @@
       %tr
         %td.achtung= image_tag "/images/achtung.png"
         %td.note
-          Most of Mongoid's criteria has been extracted into it's own
-          gem, Origin, which Mongoid now depends on for most of it's API.
+          Most of Mongoid's criteria has been extracted into its own
+          gem, Origin, which Mongoid now depends on for most of its API.
           A complete list of commands can be found in
           <a href="/en/origin/docs/selection.html">Selection with Origin</a>
           and <a href="/en/origin/docs/options.html">Options with Origin</a>.
@@ -696,7 +696,7 @@
     <code>has_many</code>, <code>has_and_belongs_to_many</code>, or
     <code>embeds_many</code>, you must reload the relation to have scoping reapplied.
     This is important to note if you change a value of a document in the relation
-    that would affect it's visibility within the scoped relation.
+    that would affect its visibility within the scoped relation.
 
   :coderay
     #!ruby

--- a/source/en/mongoid/docs/relations.haml
+++ b/source/en/mongoid/docs/relations.haml
@@ -164,7 +164,7 @@
 
   %p
     If you want the embedded document callbacks to fire when calling a persistence
-    operation on it's parent, you will need to provide the cascade callbacks
+    operation on its parent, you will need to provide the cascade callbacks
     option to the relation.
 
   .well
@@ -1138,7 +1138,7 @@
   %h3 Storage
 
   %p
-    When defining a relation of this nature, each document is stored in it's
+    When defining a relation of this nature, each document is stored in its
     respective collection, but the child document contains a "foreign key"
     reference to the parent.
 
@@ -1299,7 +1299,7 @@
   %h3 Storage
 
   %p
-    When defining a relation of this nature, each document is stored in it's
+    When defining a relation of this nature, each document is stored in its
     respective collection, but the child document contains a "foreign key"
     reference to the parent.
 
@@ -1691,7 +1691,7 @@
   %h3 Storage
 
   %p
-    When defining a relation of this nature, each document is stored in it's
+    When defining a relation of this nature, each document is stored in its
     respective collection, and each document contains a "foreign key"
     reference to the other in the form of an array.
 

--- a/source/en/mongoid/docs/upgrading.haml
+++ b/source/en/mongoid/docs/upgrading.haml
@@ -59,7 +59,7 @@
         index({ name: 1 }, { unique: true, background: true })
       end
 
-    %p Geospacial indexing needs "2d" as it's direction.
+    %p Geospacial indexing needs "2d" as its direction.
 
     :coderay
       #!ruby
@@ -278,12 +278,12 @@
       the relation will return empty results.
 
     %p
-      If the id is set and it's document is persisted, accessing the relation
+      If the id is set and its document is persisted, accessing the relation
       will return the document.
 
     %p
       If the id is set, but the base document is not saved afterwards, then
-      reloading will return the document to it's original state.
+      reloading will return the document to its original state.
 
   %li
     %i.icon-warning-sign

--- a/source/en/moped/docs/driver.haml
+++ b/source/en/moped/docs/driver.haml
@@ -251,7 +251,7 @@
           <code>Indexes#[]</code>
           %p.doc
             %i
-              Get an index by it's spec.
+              Get an index by its spec.
         %td
           :coderay
             #!ruby

--- a/source/en/origin/docs/installation.haml
+++ b/source/en/origin/docs/installation.haml
@@ -68,7 +68,7 @@
             the additional selection.
 
   %p
-    At any time you can ask the queryable for a <code>selector</code> or it's
+    At any time you can ask the queryable for a <code>selector</code> or its
     <code>options</code>, which can then be used with your favourite driver
     to query the database for documents.
 
@@ -118,7 +118,7 @@
     <code>Queryable</code> object manually, but provide an easier way to
     generate them from models. Origin provides a <code>Origin::Forwardable</code>
     module to allow you to specify a method to create queryables from, and
-    subsequently injects all of it's public API into the model in question.
+    subsequently injects all of its public API into the model in question.
 
   :coderay
     #!ruby

--- a/source/en/origin/docs/serialization.haml
+++ b/source/en/origin/docs/serialization.haml
@@ -61,7 +61,7 @@
 
   %p
     Then when instantiating your queryable, you need to provide it a hash of
-    field name/serializer pairs as it's second argument.
+    field name/serializer pairs as its second argument.
 
   :coderay
     #!ruby


### PR DESCRIPTION
I fixed several instances where "it's" (contraction) is used where "its" (possessive) should be used.
