### PR TITLE
Clarify Paranoid delete vs. destroy

### DIFF
--- a/source/en/mongoid/docs/extras.haml
+++ b/source/en/mongoid/docs/extras.haml
@@ -46,10 +46,11 @@
       include Mongoid::Paranoia
     end
 
-    person.delete # Sets the deleted_at field to the current time.
-    person.delete! # Permanently deletes the document.
-    person.destroy! # Permanently delete the document with callbacks.
-    person.restore # Brings the "deleted" document back to life.
+    person.delete   # Sets the deleted_at field to the current time, ignoring callbacks.
+    person.delete!  # Permanently deletes the document, ignoring callbacks.
+    person.destroy  # Sets the deleted_at field to the current time, firing callbacks.
+    person.destroy! # Permanently deletes the document, firing callbacks.
+    person.restore  # Brings the "deleted" document back to life.
 
   %p
     The documents that have been "flagged" as deleted (soft deleted)


### PR DESCRIPTION
- Added info about the standard "destroy" method to the info about Mongoid::Paranoid. Before, it seemed like "delete" was the only way to accomplish a soft-delete.

This info seems correct to me based on the Mongoid specs and my own testing, but please verify :)
