### PR TITLE
Fixes the syntax of the indexes in the section "Localized fields"

### DIFF
--- a/source/en/mongoid/docs/documents.haml
+++ b/source/en/mongoid/docs/documents.haml
@@ -792,7 +792,7 @@
       field :name, type: String
       field :origin, type: String
 
-      attr_readonly :name, origin
+      attr_readonly :name, :origin
     end
 
     band = Band.create(name: "Placebo")


### PR DESCRIPTION
Replace:

``` ruby
class Product
  include Mongoid::Document
  field :description, localize: true

  index "description.de"
  index "description.en"
end
```

by:

``` ruby
class Product
  include Mongoid::Document
  field :description, localize: true

  index "description.de" => 1
  index "description.en" => 1
end
```
