### PR TITLE
Can't put association on both sides if one is embedded

### DIFF
--- a/source/en/mongoid/docs/relations.haml
+++ b/source/en/mongoid/docs/relations.haml
@@ -1133,7 +1133,7 @@
 
   %p
     Definitions are required on both sides to the relation in order for it to
-    work properly.
+    work properly, unless one of the models is embedded.
 
   %h3 Storage
 
@@ -1294,7 +1294,7 @@
 
   %p
     Definitions are required on both sides to the relation in order for it to
-    work properly.
+    work properly, unless one of the models is embedded.
 
   %h3 Storage
 


### PR DESCRIPTION
Updated some phrases to account for the fact that you can't have an association to an embedded document.
