### PR TITLE
Added Moped::BSON::Binary type to fields list

### DIFF
--- a/source/en/mongoid/docs/documents.haml
+++ b/source/en/mongoid/docs/documents.haml
@@ -125,6 +125,7 @@
       %li <code>Hash</code>
       %li <code>Integer</code>
       %li <code>Moped::BSON::ObjectId</code>
+      %li <code>Moped::BSON::Binary</code>
       %li <code>Range</code>
       %li <code>Regexp</code>
       %li <code>String</code>


### PR DESCRIPTION
Added the `Moped::BSON::Binary` field type, which might have [helped this Stack Overflow user](http://stackoverflow.com/questions/13106598/saving-binary-data-using-mongoid-in-rails/13106658) solve their problem.
