### PR TITLE
Added a README.md to the generated site, redirecting pull requests to the mongoid-site repo

### DIFF
--- a/static/README.md
+++ b/static/README.md
@@ -1,0 +1,3 @@
+## Generated from https://github.com/mongoid/mongoid-site
+
+### Please only submit pull requests to [mongoid/mongoid-site](https://github.com/mongoid/mongoid-site).


### PR DESCRIPTION
I didn't notice the "DO NOT EDIT DIRECTLY" text in the repo description for [mongoid/mongoid.github.com](https://github.com/mongoid/mongoid.github.com), but probably would have noticed it if a README file was present.

There are a few other pull requests on [mongoid/mongoid.github.com](https://github.com/mongoid/mongoid.github.com) that confirm that a README might be helpful.
