### PR TITLE
changed 'and' to 'an'

### DIFF
--- a/source/en/mongoid/docs/relations.haml
+++ b/source/en/mongoid/docs/relations.haml
@@ -129,7 +129,7 @@
     When a child embedded document can belong to more than one type of parent
     document, you can tell Mongoid to support this by adding the <code>as</code>
     option to the definition on the parents, and the <code>polymorphic</code>
-    option on the child. On the child object, and additional field will be
+    option on the child. On the child object, an additional field will be
     stored that indicates the type of the parent.
 
   .well


### PR DESCRIPTION
I noticed this typo while reading through the section on Polymorphism, and thought I would try fixing it. 

Great documentation!
