### PR TITLE
Fixed spelling error in Mongoid Documentation

### DIFF
--- a/source/en/mongoid/docs/relations.haml
+++ b/source/en/mongoid/docs/relations.haml
@@ -138,7 +138,7 @@
         %td.achtung= image_tag "/images/achtung.png"
         %td.note
           %p
-            Polymorhic behavior is allowed on all relations with the
+            Polymorphic behavior is allowed on all relations with the
             exception of <code>has_and_belongs_to_many</code>.
 
   :coderay


### PR DESCRIPTION
In the relations.html file, fixed the spelling of polymorphic.
polymorhic -> polymorphic
