### PR TITLE
Small clarification to documentation

### DIFF
--- a/source/en/mongoid/docs/querying.haml
+++ b/source/en/mongoid/docs/querying.haml
@@ -48,8 +48,8 @@
   %p
     With each chained method on a criteria, a newly cloned criteria
     is returned with the new query added. This is so that with scoping
-    or exposures, for example, the original queries are not modified
-    and reusable.
+    or exposures, for example, the original queries are unmodified
+    and remain reusable.
 
   .well
     %table


### PR DESCRIPTION
Use language that makes it a little bit more clear that it is `(NOT foo) AND (bar)` instead of `NOT (foo AND bar)`
