### PR TITLE
Rails 4 has dropped ActiveResource.

### DIFF
--- a/source/en/mongoid/docs/installation.haml
+++ b/source/en/mongoid/docs/installation.haml
@@ -279,7 +279,7 @@
     #!ruby
     require "action_controller/railtie"
     require "action_mailer/railtie"
-    require "active_resource/railtie"
+    require "active_resource/railtie" # Comment this line for Rails 4.0+
     require "rails/test_unit/railtie"
     # require "sprockets/railtie" # Uncomment this line for Rails 3.1+
 


### PR DESCRIPTION
 Amend mongoid/installation
