### PR TITLE
Fix error in rename documentation

### DIFF
--- a/source/en/mongoid/docs/persistence.haml
+++ b/source/en/mongoid/docs/persistence.haml
@@ -492,7 +492,7 @@
           %td
             :coderay
               #!ruby
-              person.rename(:bday, :dob)
+              person.rename(bday: :dob)
           %td
             :coderay
               #!ruby


### PR DESCRIPTION
The curent documentation would cause an error, this correction follows the spec : https://github.com/mongoid/mongoid/blob/master/spec/mongoid/persistable/renamable_spec.rb#L63
