### PR TITLE
Fix update and update_all examples to property set fields.

### DIFF
--- a/source/en/moped/docs/driver.haml
+++ b/source/en/moped/docs/driver.haml
@@ -417,7 +417,7 @@
         %td
           :coderay
             #!ruby
-            query.update(name: "Tool")
+            query.update('$set' => {name: "Tool"})
       %tr
         %td.doc
           <code>Query#update_all</code>
@@ -427,7 +427,7 @@
         %td
           :coderay
             #!ruby
-            query.update_all(pending: true)
+            query.update_all('$set' => {pending: true})
       %tr
         %td.doc
           <code>Query#upsert</code>


### PR DESCRIPTION
The examples for `update` and `update_all` should use `$set`. See https://github.com/mongoid/moped/issues/147#issuecomment-14123941 and https://github.com/mongoid/moped/pull/213
