### PR TITLE
Fix spelling: geospacial => geospatial

### DIFF
--- a/source/en/mongoid/docs/indexing.haml
+++ b/source/en/mongoid/docs/indexing.haml
@@ -65,7 +65,7 @@
   end
 
 %p
-  For geospacial indexes, make sure the field you are indexing is an <tt>Array</tt>.
+  For geospatial indexes, make sure the field you are indexing is an <tt>Array</tt>.
 
 :coderay
   #!ruby

--- a/source/en/mongoid/docs/upgrading.haml
+++ b/source/en/mongoid/docs/upgrading.haml
@@ -65,7 +65,7 @@
         index({ name: 1 }, { unique: true, background: true })
       end
 
-    %p Geospacial indexing needs "2d" as its direction.
+    %p Geospatial indexing needs "2d" as its direction.
 
     :coderay
       #!ruby


### PR DESCRIPTION
http://www.oxforddictionaries.com/definition/english/geospatial
http://dictionary.reference.com/browse/geospatial

vs.

http://www.oxforddictionaries.com/definition/english/geospacial
http://dictionary.reference.com/browse/geospacial
