### PR TITLE
Update install docs for Rails 4

### DIFF
--- a/source/en/mongoid/docs/installation.haml
+++ b/source/en/mongoid/docs/installation.haml
@@ -286,16 +286,20 @@
   %p
     For Rails 3.2+ you'll also need to remove configuration options for
     Active Record that reside in your environments, ie
-    <code>myapp/config/environments/development.rb</code>. Make sure the
-    lines are commented out like as follows.
+    <code>myapp/config/environments/development.rb</code>. Make sure any
+    references to <code>active_record</code> are commented out like as follows
 
   :coderay
     #!ruby
+    # Rails 3.2+, < 4.0
     # config.active_record.mass_assignment_sanitizer = :strict
     # config.active_record.auto_explain_threshold_in_seconds = 0.5
+    #
+    # Rails 4.0+
+    # config.active_record.migration_error = :page_load
 
   %p
-    For Rails 3.2.3+ you'll also need to comment out the following line in
+    For Rails 3.2.3+ but < 4.0 you'll also need to comment out the following line in
     <code>myapp/config/application.rb</code>.
 
   :coderay


### PR DESCRIPTION
A few references didn't exactly match what is expected in
a Rails 4 app. I've kept the 3.2 references and added 4.0
