### PR TITLE
Fixed a link to the "One Spec to Rule them All"

### DIFF
--- a/source/en/mongoid/docs/nested_attributes.haml
+++ b/source/en/mongoid/docs/nested_attributes.haml
@@ -61,7 +61,7 @@
     Mongoid. This includes: <code>update_attributes</code>,
     <code>update_attributes!</code> and <code>attributes=</code>. For full
     examples of every single scenario you could possibly imagine, see the
-    <a href="https://github.com/mongoid/mongoid/blob/master/spec/mongoid/nested_attributes_spec.rb">One Spec to Rule them All</a>.
+    <a href="https://github.com/mongoid/mongoid/blob/master/spec/mongoid/attributes/nested_spec.rb">One Spec to Rule them All</a>.
 
 %section#operations
   %h2 Operations


### PR DESCRIPTION
In https://github.com/mongoid/mongoid/commit/01ed3f6ec6e39cd938c5b66be29a19875a679620#diff-bb1b905fa1adea594d0d1aacadce9582,

This file:
https://github.com/mongoid/mongoid/blob/master/spec/mongoid/nested_attributes_spec.rb

Was moved to:
https://github.com/mongoid/mongoid/blob/master/spec/mongoid/attributes/nested_spec.rb
