### PR TITLE
Updating docs that use hash arguments instead of multiple params

### DIFF
--- a/source/en/mongoid/docs/persistence.haml
+++ b/source/en/mongoid/docs/persistence.haml
@@ -408,7 +408,7 @@
           %td
             :coderay
               #!ruby
-              person.inc(:age, 1)
+              person.inc(age: 1)
           %td
             :coderay
               #!ruby
@@ -422,7 +422,7 @@
           %td
             :coderay
               #!ruby
-              person.pop(:aliases, 1)
+              person.pop(aliases: 1)
           %td
             :coderay
               #!ruby
@@ -436,7 +436,7 @@
           %td
             :coderay
               #!ruby
-              person.pull(:aliases, "Bond")
+              person.pull(aliases: "Bond")
           %td
             :coderay
               #!ruby
@@ -464,7 +464,7 @@
           %td
             :coderay
               #!ruby
-              person.push(:aliases, "007")
+              person.push(aliases: "007")
           %td
             :coderay
               #!ruby
@@ -492,7 +492,7 @@
           %td
             :coderay
               #!ruby
-              person.rename(:bday, :dob)
+              person.rename(bday: :dob)
           %td
             :coderay
               #!ruby
@@ -506,7 +506,7 @@
           %td
             :coderay
               #!ruby
-              person.set(:name, "Tyler Durden")
+              person.set(name: "Tyler Durden")
           %td
             :coderay
               #!ruby

--- a/source/en/mongoid/docs/querying.haml
+++ b/source/en/mongoid/docs/querying.haml
@@ -542,7 +542,7 @@
         %td
           :coderay
             #!ruby
-            Band.where(name: "Photek").inc(:likes, 123)
+            Band.where(name: "Photek").inc(likes: 123)
         %td
           :coderay
             #!ruby
@@ -557,8 +557,8 @@
         %td
           :coderay
             #!ruby
-            Band.where(name: "Photek").pop(:members, -1)
-            Band.where(name: "Photek").pop(:members, 1)
+            Band.where(name: "Photek").pop(members: -1)
+            Band.where(name: "Photek").pop(members: 1)
         %td
           :coderay
             #!ruby
@@ -577,7 +577,7 @@
         %td
           :coderay
             #!ruby
-            Band.where(name: "Tool").pull(:members, "Maynard")
+            Band.where(name: "Tool").pull(members: "Maynard")
         %td
           :coderay
             #!ruby
@@ -610,7 +610,7 @@
         %td
           :coderay
             #!ruby
-            Band.where(name: "Tool").push(:members, "Maynard")
+            Band.where(name: "Tool").push(members: "Maynard")
         %td
           :coderay
             #!ruby
@@ -645,7 +645,7 @@
         %td
           :coderay
             #!ruby
-            Band.where(name: "Tool").rename(:name, :title)
+            Band.where(name: "Tool").rename(name: :title)
         %td
           :coderay
             #!ruby
@@ -660,7 +660,7 @@
         %td
           :coderay
             #!ruby
-            Band.where(name: "Tool").set(:likes, 10000)
+            Band.where(name: "Tool").set(likes: 10000)
         %td
           :coderay
             #!ruby


### PR DESCRIPTION
There are many outdated examples that show methods that have multiple arguments, when they actually take a hash.
