### PR TITLE
FIX code typo

### DIFF
--- a/source/en/origin/docs/selection.haml
+++ b/source/en/origin/docs/selection.haml
@@ -573,7 +573,7 @@
         %td
           :coderay
             #!ruby
-            queryable.where(:age.gt 18)
+            queryable.where(:age.gt => 18)
         %td
           :coderay
             #!ruby


### PR DESCRIPTION
the pervious code `queryable.where(:age.gt 18)` was not working cause it's missing `=>` operator
