### PR TITLE
Fix update_attributes doc for v3 (the method is not atomic)

### DIFF
--- a/source/en/mongoid/v3/persistence.haml
+++ b/source/en/mongoid/v3/persistence.haml
@@ -170,7 +170,7 @@
           <code>Model#update_attributes</code>
           %p.doc
             %i
-              Update the provided attributes atomically.
+              Update the provided attributes (and any other dirty fields).
         %td
           :coderay
             #!ruby


### PR DESCRIPTION
Already done for v4 (see https://github.com/mongoid/mongoid-site/pull/263).