### PR TITLE
Move link to v3 docs out of main menu

### DIFF
--- a/source/en/layouts/mongoid.haml
+++ b/source/en/layouts/mongoid.haml
@@ -36,27 +36,6 @@
                 %li= link_to "Contributing", "/en/mongoid/docs/contributing.html"
                 %li= link_to "Performance", "/en/mongoid/docs/performance.html"
                 %li= link_to "Tips/FAQs", "/en/mongoid/docs/tips.html"
-            %li.dropdown#docs
-              %a.dropdown-toggle{:"data-toggle" => "dropdown", href: "#docsv3"}
-                docs 3.x
-                %b.caret
-              %ul.dropdown-menu
-                %li= link_to "Installation", "/en/mongoid/v3/installation.html"
-                %li= link_to "Documents", "/en/mongoid/v3/documents.html"
-                %li= link_to "Persistence", "/en/mongoid/v3/persistence.html"
-                %li= link_to "Querying", "/en/mongoid/v3/querying.html"
-                %li= link_to "Relations", "/en/mongoid/v3/relations.html"
-                %li= link_to "Nested Attributes", "/en/mongoid/v3/nested_attributes.html"
-                %li= link_to "Identity Map", "/en/mongoid/v3/identity_map.html"
-                %li= link_to "Callbacks", "/en/mongoid/v3/callbacks.html"
-                %li= link_to "Validation", "/en/mongoid/v3/validation.html"
-                %li= link_to "Indexing", "/en/mongoid/v3/indexing.html"
-                %li= link_to "Rails", "/en/mongoid/v3/rails.html"
-                %li= link_to "Extras", "/en/mongoid/v3/extras.html"
-                %li= link_to "Upgrading", "/en/mongoid/v3/upgrading.html"
-                %li= link_to "Contributing", "/en/mongoid/v3/contributing.html"
-                %li= link_to "Performance", "/en/mongoid/v3/performance.html"
-                %li= link_to "Tips/FAQs", "/en/mongoid/v3/tips.html"
             %li= link_to "LINKS", "/en/mongoid/links.html"
             %li= link_to "DONATE", "/en/mongoid/donate.html"
 

--- a/source/en/mongoid/docs/callbacks.haml
+++ b/source/en/mongoid/docs/callbacks.haml
@@ -1,3 +1,5 @@
+= partial '../partials/mongoid_v4', locals: { page: 'callbacks' }
+
 - content_for :head do
   %title Mongoid: Callbacks
 

--- a/source/en/mongoid/docs/contributing.haml
+++ b/source/en/mongoid/docs/contributing.haml
@@ -1,3 +1,5 @@
+= partial '../partials/mongoid_v4', locals: { page: 'contributing' }
+
 - content_for :head do
   %title Mongoid: Contributing
 

--- a/source/en/mongoid/docs/documents.haml
+++ b/source/en/mongoid/docs/documents.haml
@@ -1,3 +1,5 @@
+= partial '../partials/mongoid_v4', locals: { page: 'documents' }
+
 - content_for :head do
   %title Mongoid: Documents
 

--- a/source/en/mongoid/docs/extras.haml
+++ b/source/en/mongoid/docs/extras.haml
@@ -1,3 +1,5 @@
+= partial '../partials/mongoid_v4', locals: { page: 'extras' }
+
 - content_for :head do
   %title Mongoid: Extras
 

--- a/source/en/mongoid/docs/indexing.haml
+++ b/source/en/mongoid/docs/indexing.haml
@@ -1,3 +1,5 @@
+= partial '../partials/mongoid_v4', locals: { page: 'indexing' }
+
 - content_for :head do
   %title Mongoid: Indexing
 

--- a/source/en/mongoid/docs/installation.haml
+++ b/source/en/mongoid/docs/installation.haml
@@ -1,3 +1,5 @@
+= partial '../partials/mongoid_v4', locals: { page: 'installation' }
+
 - content_for :head do
   %title Mongoid: Installation
 

--- a/source/en/mongoid/docs/nested_attributes.haml
+++ b/source/en/mongoid/docs/nested_attributes.haml
@@ -1,3 +1,5 @@
+= partial '../partials/mongoid_v4', locals: { page: 'nested_attributes' }
+
 - content_for :head do
   %title Mongoid: Nested Attributes
 

--- a/source/en/mongoid/docs/performance.haml
+++ b/source/en/mongoid/docs/performance.haml
@@ -1,3 +1,5 @@
+= partial '../partials/mongoid_v4', locals: { page: 'performance' }
+
 - content_for :head do
   %title Mongoid: Performance
 

--- a/source/en/mongoid/docs/persistence.haml
+++ b/source/en/mongoid/docs/persistence.haml
@@ -1,3 +1,5 @@
+= partial '../partials/mongoid_v4', locals: { page: 'persistence' }
+
 - content_for :head do
   %title Mongoid: Persistence
 

--- a/source/en/mongoid/docs/querying.haml
+++ b/source/en/mongoid/docs/querying.haml
@@ -1,3 +1,5 @@
+= partial '../partials/mongoid_v4', locals: { page: 'querying' }
+
 - content_for :head do
   %title Mongoid: Querying
 

--- a/source/en/mongoid/docs/rails.haml
+++ b/source/en/mongoid/docs/rails.haml
@@ -1,3 +1,5 @@
+= partial '../partials/mongoid_v4', locals: { page: 'rails' }
+
 - content_for :head do
   %title Mongoid: Rails
 

--- a/source/en/mongoid/docs/relations.haml
+++ b/source/en/mongoid/docs/relations.haml
@@ -1,3 +1,5 @@
+= partial '../partials/mongoid_v4', locals: { page: 'relations' }
+
 - content_for :head do
   %title Mongoid: Relations
 

--- a/source/en/mongoid/docs/tips.haml
+++ b/source/en/mongoid/docs/tips.haml
@@ -1,3 +1,5 @@
+= partial '../partials/mongoid_v4', locals: { page: 'tips' }
+
 - content_for :head do
   %title Mongoid: Tips
 

--- a/source/en/mongoid/docs/upgrading.haml
+++ b/source/en/mongoid/docs/upgrading.haml
@@ -1,3 +1,5 @@
+= partial '../partials/mongoid_v4', locals: { page: 'upgrading' }
+
 - content_for :head do
   %title Mongoid: Upgrading
 

--- a/source/en/mongoid/docs/validation.haml
+++ b/source/en/mongoid/docs/validation.haml
@@ -1,3 +1,5 @@
+= partial '../partials/mongoid_v4', locals: { page: 'validation' }
+
 - content_for :head do
   %title Mongoid: Validation
 

--- a/source/en/mongoid/partials/_mongoid_v3.haml
+++ b/source/en/mongoid/partials/_mongoid_v3.haml
@@ -1,0 +1,5 @@
+%p
+
+%p{style: 'background-color:#EEE;padding: 5px 10px;'} 
+  You are looking at the docs for v3.x. Check out this page on the docs for Mongoid 
+  %a{href: "/en/mongoid/docs/#{page}.html"} v4.x

--- a/source/en/mongoid/partials/_mongoid_v4.haml
+++ b/source/en/mongoid/partials/_mongoid_v4.haml
@@ -1,0 +1,4 @@
+%p{style: 'background-color:#EEE;padding: 5px 10px;margin-top:30px;'} 
+  You are looking at the docs for v4.x. You can check out this page for Mongoid 
+  %a{href: "/en/mongoid/v3/#{page}.html"} v3.x
+  if you haven't upgraded yet.

--- a/source/en/mongoid/v3/callbacks.haml
+++ b/source/en/mongoid/v3/callbacks.haml
@@ -1,3 +1,5 @@
+= partial '../partials/mongoid_v3', locals: { page: 'callbacks' }
+
 - content_for :head do
   %title Mongoid: Callbacks
 

--- a/source/en/mongoid/v3/contributing.haml
+++ b/source/en/mongoid/v3/contributing.haml
@@ -1,3 +1,5 @@
+= partial '../partials/mongoid_v3', locals: { page: 'contributing' }
+
 - content_for :head do
   %title Mongoid: Contributing
 

--- a/source/en/mongoid/v3/documents.haml
+++ b/source/en/mongoid/v3/documents.haml
@@ -1,3 +1,5 @@
+= partial '../partials/mongoid_v3', locals: { page: 'documents' }
+
 - content_for :head do
   %title Mongoid: Documents
 

--- a/source/en/mongoid/v3/extras.haml
+++ b/source/en/mongoid/v3/extras.haml
@@ -1,3 +1,5 @@
+= partial '../partials/mongoid_v3', locals: { page: 'extras' }
+
 - content_for :head do
   %title Mongoid: Extras
 

--- a/source/en/mongoid/v3/indexing.haml
+++ b/source/en/mongoid/v3/indexing.haml
@@ -1,3 +1,5 @@
+= partial '../partials/mongoid_v3', locals: { page: 'indexing' }
+
 - content_for :head do
   %title Mongoid: Indexing
 

--- a/source/en/mongoid/v3/installation.haml
+++ b/source/en/mongoid/v3/installation.haml
@@ -1,3 +1,5 @@
+= partial '../partials/mongoid_v3', locals: { page: 'installation' }
+
 - content_for :head do
   %title Mongoid: Installation
 

--- a/source/en/mongoid/v3/nested_attributes.haml
+++ b/source/en/mongoid/v3/nested_attributes.haml
@@ -1,3 +1,5 @@
+= partial '../partials/mongoid_v3', locals: { page: 'nested_attributes' }
+
 - content_for :head do
   %title Mongoid: Nested Attributes
 

--- a/source/en/mongoid/v3/performance.haml
+++ b/source/en/mongoid/v3/performance.haml
@@ -1,3 +1,5 @@
+= partial '../partials/mongoid_v3', locals: { page: 'performance' }
+
 - content_for :head do
   %title Mongoid: Performance
 

--- a/source/en/mongoid/v3/persistence.haml
+++ b/source/en/mongoid/v3/persistence.haml
@@ -1,3 +1,5 @@
+= partial '../partials/mongoid_v3', locals: { page: 'persistence' }
+
 - content_for :head do
   %title Mongoid: Persistence
 

--- a/source/en/mongoid/v3/querying.haml
+++ b/source/en/mongoid/v3/querying.haml
@@ -1,3 +1,5 @@
+= partial '../partials/mongoid_v3', locals: { page: 'querying' }
+
 - content_for :head do
   %title Mongoid: Querying
 

--- a/source/en/mongoid/v3/rails.haml
+++ b/source/en/mongoid/v3/rails.haml
@@ -1,3 +1,5 @@
+= partial '../partials/mongoid_v3', locals: { page: 'rails' }
+
 - content_for :head do
   %title Mongoid: Rails
 

--- a/source/en/mongoid/v3/relations.haml
+++ b/source/en/mongoid/v3/relations.haml
@@ -1,3 +1,5 @@
+= partial '../partials/mongoid_v3', locals: { page: 'relations' }
+
 - content_for :head do
   %title Mongoid: Relations
 

--- a/source/en/mongoid/v3/tips.haml
+++ b/source/en/mongoid/v3/tips.haml
@@ -1,3 +1,5 @@
+= partial '../partials/mongoid_v3', locals: { page: 'tips' }
+
 - content_for :head do
   %title Mongoid: Tips
 

--- a/source/en/mongoid/v3/upgrading.haml
+++ b/source/en/mongoid/v3/upgrading.haml
@@ -1,3 +1,5 @@
+= partial '../partials/mongoid_v3', locals: { page: 'upgrading' }
+
 - content_for :head do
   %title Mongoid: Upgrading
 

--- a/source/en/mongoid/v3/validation.haml
+++ b/source/en/mongoid/v3/validation.haml
@@ -1,3 +1,5 @@
+= partial '../partials/mongoid_v3', locals: { page: 'validation' }
+
 - content_for :head do
   %title Mongoid: Validation
 


### PR DESCRIPTION
Following the suggestion received in #266, I removed the link to the v.3.x docs from the main menu. This way, we enforce the idea that v4 is the one everybody should refer to. 

Since there's already some sort of second level menu (each page has its own), I made it possible to jump back and forth from one version to another with a simple link at the top of each page. 

You can preview the outcome here (a v4 page: http://prntscr.com/6w8qdt) and here (a v3 page: http://prntscr.com/6w8qr9)

Every suggestion to made it clearer (including better texts for the links) are welcome indeed.